### PR TITLE
Use pre-allocated Avro::IO::DatumWriter in format

### DIFF
--- a/lib/fluent/plugin/formatter_avro.rb
+++ b/lib/fluent/plugin/formatter_avro.rb
@@ -18,13 +18,13 @@ module Fluent
           @schema_json = File.read(@schema_file)
         end
         @schema = Avro::Schema.parse(@schema_json)
+        @writer = Avro::IO::DatumWriter.new(@schema)
       end
 
       def format(tag, time, record)
-        writer = Avro::IO::DatumWriter.new(@schema)
         buffer = StringIO.new
         encoder = Avro::IO::BinaryEncoder.new(buffer)
-        writer.write(record, encoder)
+        @writer.write(record, encoder)
         buffer.string
       end
     end


### PR DESCRIPTION
Avro::IO::DatumWriter doesn't modify internal state during #write
so we can share it to reduce memory allocation