### PR TITLE
Parse newly fetched object not old one in memory

### DIFF
--- a/fluent-plugin-avro.gemspec
+++ b/fluent-plugin-avro.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-avro"
-  spec.version       = "1.1.0"
+  spec.version       = "1.1.1"
   spec.authors       = ["Shun Takebayashi"]
   spec.email         = ["shun@takebayashi.asia"]
 

--- a/lib/fluent/plugin/formatter_avro.rb
+++ b/lib/fluent/plugin/formatter_avro.rb
@@ -39,7 +39,7 @@ module Fluent
           schema_changed = false
           begin
             new_schema_json = fetch_schema(@schema_url,@schema_url_key)
-            new_schema = Avro::Schema.parse(@schema_json)
+            new_schema = Avro::Schema.parse(@new_schema_json)
             schema_changed = (new_schema_json == @schema_json)
             @schema_json = new_schema_json
             @schema = new_schema

--- a/lib/fluent/plugin/formatter_avro.rb
+++ b/lib/fluent/plugin/formatter_avro.rb
@@ -39,7 +39,7 @@ module Fluent
           schema_changed = false
           begin
             new_schema_json = fetch_schema(@schema_url,@schema_url_key)
-            new_schema = Avro::Schema.parse(@new_schema_json)
+            new_schema = Avro::Schema.parse(new_schema_json)
             schema_changed = (new_schema_json == @schema_json)
             @schema_json = new_schema_json
             @schema = new_schema


### PR DESCRIPTION
Upon reviewing the code, I noticed new schemas were not being parsed unless restarted... This was the issue, I was not using the new_schema_json when parsing. This is that simple fix, plus a version bump for convenience.